### PR TITLE
README: Remove --no-quarantine from Homebrew command

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Pre-compiled, always up-to-date versions are available from my [releases](https:
 
 You can add the app via Homebrew by tapping my homebrew repo directly:
 ```
-brew install alienator88/homebrew-cask/pearcleaner --no-quarantine
+brew install alienator88/homebrew-cask/pearcleaner
 ```
 </details>
 


### PR DESCRIPTION
Seeing as the app is signed and notarised. Note the flag is still present on [the website](https://itsalin.com/appInfo/?id=pearcleaner).