### PR TITLE
Excluding unwanted strings from translation.

### DIFF
--- a/Pearcleaner/Resources/Localizable.xcstrings
+++ b/Pearcleaner/Resources/Localizable.xcstrings
@@ -1,39 +1,11 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "needs_review",
-            "value" : ""
-          }
-        }
-      },
-      "shouldTranslate" : false
-    },
     "(Build %@)" : {
 
     },
     "/Full/Path/example-1.txt, /Full/Path/example-2.txt" : {
 
-    },
-    "%@" : {
-      "shouldTranslate" : false
-    },
-    "%lld" : {
-      "shouldTranslate" : false
-    },
-    "%lld %@ %lld %@" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$lld %2$@ %3$lld %4$@"
-          }
-        }
-      },
-      "shouldTranslate" : false
     },
     "•" : {
       "localizations" : {

--- a/Pearcleaner/Settings/About.swift
+++ b/Pearcleaner/Settings/About.swift
@@ -72,9 +72,9 @@ struct AboutSettingsTab: View {
 
                         }
                         Spacer()
-                        Button(""){
+                        Button {
                             NSWorkspace.shared.open(URL(string: "https://github.com/alienator88/Pearcleaner/issues/new/choose")!)
-                        }
+                        } label: { EmptyView() }
                         .buttonStyle(SimpleButtonStyle(icon: "paperplane", help: String(localized: "View")))
 
                     }
@@ -92,16 +92,16 @@ struct AboutSettingsTab: View {
 
                         Text("View project contributors")
 
-                        DisclosureGroup("", isExpanded: $disclose, content: {
+                        DisclosureGroup(isExpanded: $disclose) {
                             ScrollView {
                                 LazyVStack(alignment: .leading, spacing: 0) {
                                     ForEach(sponsors) { sponsor in
                                         HStack() {
                                             Text(sponsor.name)
                                             Spacer()
-                                            Button(""){
+                                            Button {
                                                 NSWorkspace.shared.open(sponsor.url)
-                                            }
+                                            } label: { EmptyView() }
                                             .buttonStyle(SimpleButtonStyle(icon: "link", help: String(localized: "View")))
                                             .padding(.trailing)
                                         }
@@ -111,7 +111,7 @@ struct AboutSettingsTab: View {
                             }
                             .frame(height: 45)
                             .padding(5)
-                        })
+                        } label: { EmptyView() }
 
 //                        Button(action: {
 //                            NSWorkspace.shared.open(URL(string: "https://github.com/sponsors/alienator88")!)

--- a/Pearcleaner/Settings/Folders.swift
+++ b/Pearcleaner/Settings/Folders.swift
@@ -96,9 +96,9 @@ struct FolderSettingsTab: View {
                     HStack {
                         Spacer()
                         Text("Drop folders above or click to add").opacity(0.5)
-                        Button("") {
+                        Button {
                             selectFolder()
-                        }
+                        } label: { EmptyView() }
                         .buttonStyle(SimpleButtonStyle(icon: "plus.circle", help: String(localized: "Add folder"), size: 16, rotate: true))
                         Spacer()
                     }
@@ -183,9 +183,9 @@ struct FolderSettingsTab: View {
                     HStack {
                         Spacer()
                         Text("Drop files or folders above or click to add").opacity(0.5)
-                        Button("") {
+                        Button {
                             selectFilesFoldersZ()
-                        }
+                        } label: { EmptyView() }
                         .buttonStyle(SimpleButtonStyle(icon: "plus.circle", help: String(localized: "Add file/folder"), size: 16, rotate: true))
                         Spacer()
                     }

--- a/Pearcleaner/Settings/General.swift
+++ b/Pearcleaner/Settings/General.swift
@@ -146,14 +146,14 @@ struct GeneralSettingsTab: View {
                             }
                             InfoButton(text: String(localized: "Real size type will show how much actual allocated space the file has on disk.\n\nLogical type shows the binary size. The filesystem can compress and deduplicate sectors on disk, so real size is sometimes smaller(or bigger) than logical size.\n\nFinder size is similar to if you right click > Get Info on a file in Finder, which will show both the logical and real sizes together."))
                             Spacer()
-                            Picker("", selection: $sizeType) {
+                            Picker(selection: $sizeType) {
                                 Text("Real")
                                     .tag("Real")
                                 Text("Logical")
                                     .tag("Logical")
 //                                Text("Finder")
 //                                    .tag("Finder")
-                            }
+                            } label: { EmptyView() }
                             .buttonStyle(.borderless)
 
                         }

--- a/Pearcleaner/Settings/Interface.swift
+++ b/Pearcleaner/Settings/Interface.swift
@@ -371,7 +371,7 @@ struct InterfaceSettingsTab: View {
                                 .foregroundStyle(.primary)
                         }
                         Spacer()
-                        Picker("", selection: $selectedMenubarIcon) {
+                        Picker(selection: $selectedMenubarIcon) {
                             ForEach(icons, id: \.self) { icon in
                                 HStack {
                                     Image(systemName: icon)
@@ -381,7 +381,7 @@ struct InterfaceSettingsTab: View {
                                 .tag(icon)
 
                             }
-                        }
+                        } label: { EmptyView() }
                         .frame(width: 60)
                         .onChange(of: selectedMenubarIcon) { newValue in
                             MenuBarExtraManager.shared.swapMenuBarIcon(icon: newValue)

--- a/Pearcleaner/Settings/Interface.swift
+++ b/Pearcleaner/Settings/Interface.swift
@@ -158,7 +158,7 @@ struct InterfaceSettingsTab: View {
                         })
                         .toggleStyle(.switch)
                         .disabled(menubarEnabled)
-                        .help(menubarEnabled ? String(localized: "Disabled when menubar icon is enabled") : String(localized: ""))
+                        .help(menubarEnabled ? String(localized: "Disabled when menubar icon is enabled") : "")
                         .onChange(of: mini) { newVal in
                             if mini {
                                 appState.currentView = miniView ? .apps : .empty

--- a/Pearcleaner/Settings/SettingsWindow.swift
+++ b/Pearcleaner/Settings/SettingsWindow.swift
@@ -68,9 +68,9 @@ struct SettingsView: View {
             Text("v\(Bundle.main.version)").foregroundStyle(.secondary)
                 .padding(.bottom, 4)
 
-            Button("") {
+            Button {
                 resetUserDefaults()
-            }
+            } label: { EmptyView() }
             .buttonStyle(ResetSettingsButtonStyle(isResetting: $isResetting, label: String(localized: "Reset Settings"), help: String(localized: "Reset all settings to default")))
             .disabled(isResetting)
 

--- a/Pearcleaner/Settings/SettingsWindow.swift
+++ b/Pearcleaner/Settings/SettingsWindow.swift
@@ -28,7 +28,7 @@ struct SettingsView: View {
                 detailView
             }
         }
-        .navigationTitle("")
+        .navigationTitle(Text(verbatim: ""))
         .frame(width: 750, height: 620)
     }
 

--- a/Pearcleaner/Settings/Update.swift
+++ b/Pearcleaner/Settings/Update.swift
@@ -35,21 +35,21 @@ struct UpdateSettingsTab: View {
 
             HStack(alignment: .center, spacing: 20) {
 
-                Button(""){
+                Button {
                     updater.checkForUpdatesForce(showSheet: false)
-                }
+                } label: { EmptyView() }
                 .buttonStyle(SimpleButtonStyle(icon: "arrow.uturn.left.circle", label: String(localized: "Refresh"), help: String(localized: "Refresh updater")))
 
 
-                Button(""){
+                Button {
                     updater.resetAnnouncementAlert()
-                }
+                } label: { EmptyView() }
                 .buttonStyle(SimpleButtonStyle(icon: "star", label: String(localized: "Announcement"), help: String(localized: "Show announcements badge again")))
 
 
-                Button(""){
+                Button {
                     NSWorkspace.shared.open(URL(string: "https://github.com/alienator88/Pearcleaner/releases")!)
-                }
+                } label: { EmptyView() }
                 .buttonStyle(SimpleButtonStyle(icon: "link", label: String(localized: "Releases"), help: String(localized: "View releases on GitHub")))
             }
 

--- a/Pearcleaner/Views/AppSearchView.swift
+++ b/Pearcleaner/Views/AppSearchView.swift
@@ -92,7 +92,7 @@ struct AppSearchView: View {
                 .popover(isPresented: $showMenu) {
                     VStack(alignment: .leading) {
 
-                        Button("") {
+                        Button {
                             withAnimation(Animation.easeInOut(duration: animationEnabled ? 0.35 : 0)) {
                                 // Cycle through all enum cases using `CaseIterable`
                                 if let nextSortOption = SortOption(rawValue: selectedSortOption.rawValue + 1) {
@@ -105,17 +105,17 @@ struct AppSearchView: View {
                                     showMenu = false
                                 }
                             }
-                        }
+                        } label: { EmptyView() }
                         .buttonStyle(SimpleButtonStyle(icon: "circle.fill", label: "Sorting: \(selectedSortOption.title)", help: "Sort app list alphabetically by name or by size", size: 5))
 
                         if mini && !menubarEnabled {
-                            Button("") {
+                            Button {
                                 withAnimation(Animation.easeInOut(duration: animationEnabled ? 0.35 : 0)) {
                                     appState.currentView = .empty
                                     appState.appInfo = AppInfo.empty
                                     showPopover = false
                                 }
-                            }
+                            } label: { EmptyView() }
                             .buttonStyle(SimpleButtonStyle(icon: "circle.fill", label: "Drop Target", help: "Drop Target", size: 5))
                         }
 
@@ -168,11 +168,11 @@ struct AppSearchView: View {
                 }
             } else if search.isEmpty && (!mini || !menubarEnabled) {
 
-                Button("") {
+                Button {
                     withAnimation(Animation.easeInOut(duration: animationEnabled ? 0.35 : 0)) {
                         showMenu.toggle()
                     }
-                }
+                } label: { EmptyView() }
                 .buttonStyle(SimpleButtonStyle(icon: "line.3.horizontal.decrease.circle", help: selectedSortOption.title, size: 16))
                 .popover(isPresented: $showMenu, arrowEdge: .bottom) {
                     VStack(alignment: .leading, spacing: 10) {
@@ -183,12 +183,12 @@ struct AppSearchView: View {
                         }
                         Divider()
                         ForEach(SortOption.allCases) { option in
-                            Button("") {
+                            Button {
                                 withAnimation(Animation.easeInOut(duration: animationEnabled ? 0.35 : 0)) {
                                     selectedSortOption = option
                                     showMenu = false
                                 }
-                            }
+                            } label: { EmptyView() }
                             .buttonStyle(SimpleButtonStyle(icon: selectedSortOption == option ? "circle.inset.filled" : "circle", label: option.title, help: "", size: 5))
 
 
@@ -287,9 +287,9 @@ struct SimpleSearchStyle: TextFieldStyle {
                     Spacer()
 
                     if trash && text != "" {
-                        Button("") {
+                        Button {
                             text = ""
-                        }
+                        } label: { EmptyView() }
                         .buttonStyle(SimpleButtonStyle(icon: "delete.left.fill", help: String(localized: "Clear text"), size: 14, padding: padding))
                     }
                 }
@@ -332,7 +332,7 @@ struct SearchBar: View {
 
     var body: some View {
         HStack {
-            TextField("", text: $search)
+            TextField(text: $search) { EmptyView() }
                 .textFieldStyle(SimpleSearchStyle(trash: true, text: $search, darker: darker, glass: glass, padding: padding, sidebar: sidebar))
         }
     }

--- a/Pearcleaner/Views/AppsListView.swift
+++ b/Pearcleaner/Views/AppsListView.swift
@@ -82,9 +82,9 @@ struct Header: View {
 
     var body: some View {
         HStack {
-            Text("\(title)").foregroundStyle(.primary).opacity(0.5)
+            Text(verbatim: "\(title)").foregroundStyle(.primary).opacity(0.5)
 
-            Text("\(count)")
+            Text(verbatim: "\(count)")
                 .font(.system(size: 10))
                 .monospacedDigit()
                 .frame(minWidth: count > 99 ? 30 : 24, minHeight: 17)

--- a/Pearcleaner/Views/FilesView.swift
+++ b/Pearcleaner/Views/FilesView.swift
@@ -203,14 +203,14 @@ struct FilesView: View {
 
                     // Item selection and sorting toolbar
                     HStack() {
-                        Toggle("", isOn: Binding(
+                        Toggle(isOn: Binding(
                             get: { self.appState.selectedItems.count == self.appState.appInfo.fileSize.keys.count },
                             set: { newValue in
                                 updateOnMain {
                                     self.appState.selectedItems = newValue ? Set(self.appState.appInfo.fileSize.keys) : []
                                 }
                             }
-                        ))
+                        )) { EmptyView() }
                         .toggleStyle(SimpleCheckboxToggleStyle())
                         .help("All checkboxes")
 
@@ -272,9 +272,9 @@ struct FilesView: View {
 
                         Spacer()
 
-                        Button("") {
+                        Button {
                             selectedSortAlpha.toggle()
-                        }
+                        } label: { EmptyView() }
                         .buttonStyle(SimpleButtonStyle(icon: "line.3.horizontal.decrease.circle", label: String(localized: selectedSortAlpha ? "Name" : "Size"), help: String(localized: selectedSortAlpha ? "Sorted alphabetically" : "Sorted by size"), size: 16))
 
                     }
@@ -483,7 +483,7 @@ struct FileDetailsItem: View {
     var body: some View {
 
         HStack(alignment: .center, spacing: 20) {
-            Toggle("", isOn: Binding(
+            Toggle(isOn: Binding(
                 get: { self.appState.selectedItems.contains(self.path) },
                 set: { isChecked in
                     if isChecked {
@@ -492,7 +492,7 @@ struct FileDetailsItem: View {
                         self.appState.selectedItems.remove(self.path)
                     }
                 }
-            ))
+            )) { EmptyView() }
             .toggleStyle(SimpleCheckboxToggleStyle())
             .disabled(self.path.path.contains(".Trash"))
 

--- a/Pearcleaner/Views/FilesView.swift
+++ b/Pearcleaner/Views/FilesView.swift
@@ -109,19 +109,19 @@ struct FilesView: View {
                                     }
                                     VStack(alignment: .leading) {
                                         HStack(alignment: .center) {
-                                            Text("\(appState.appInfo.appName)").font(.title).fontWeight(.bold).lineLimit(1)
+                                            Text(verbatim: "\(appState.appInfo.appName)").font(.title).fontWeight(.bold).lineLimit(1)
                                             Image(systemName: "circle.fill").foregroundStyle(Color("AccentColor")).font(.system(size: 5))
-                                            Text("\(appState.appInfo.appVersion)").font(.title3)
+                                            Text(verbatim: "\(appState.appInfo.appVersion)").font(.title3)
 
                                         }
-                                        Text("\(appState.appInfo.bundleIdentifier)")
+                                        Text(verbatim: "\(appState.appInfo.bundleIdentifier)")
                                             .lineLimit(1)
                                             .font(.title3)
                                             .foregroundStyle((.primary.opacity(0.5)))
                                     }
                                     Spacer()
 
-                                    Button("\(detailsEnabled ? String(localized: "Hide Details") : String(localized: "Show Details"))") {
+                                    Button(detailsEnabled ? "Hide Details" : "Show Details") {
                                         withAnimation(Animation.easeInOut(duration: animationEnabled ? 0.35 : 0)) {
                                             detailsEnabled.toggle()
                                         }
@@ -135,7 +135,7 @@ struct FilesView: View {
                                         VStack(alignment: .leading, spacing: 5) {
                                             Text("Total size of files:")
                                                 .font(.callout).fontWeight(.bold)
-                                            Text("")
+                                            Text(verbatim: "")
                                                 .font(.footnote)
                                             Text("Installed Date:")
                                                 .font(.footnote)
@@ -147,9 +147,9 @@ struct FilesView: View {
                                         }
                                         Spacer()
                                         VStack(alignment: .trailing, spacing: 5) {
-                                            Text("\(displaySizeTotal)").font(.callout).fontWeight(.bold)//.help("Total size on disk")
+                                            Text(verbatim: "\(displaySizeTotal)").font(.callout).fontWeight(.bold)//.help("Total size on disk")
 
-                                            Text("\(appState.appInfo.fileSize.count == 1 ? "\(appState.selectedItems.count) \(String(localized: "of"))  \(appState.appInfo.fileSize.count) \(String(localized: "item"))" : "\(appState.selectedItems.count) \(String(localized: "of")) \(appState.appInfo.fileSize.count) \(String(localized: "items"))")")
+                                            Text(verbatim: "\(appState.appInfo.fileSize.count == 1 ? "\(appState.selectedItems.count) \(String(localized: "of"))  \(appState.appInfo.fileSize.count) \(String(localized: "item"))" : "\(appState.selectedItems.count) \(String(localized: "of")) \(appState.appInfo.fileSize.count) \(String(localized: "items"))")")
                                                 .font(.footnote)
 
                                             if let creationDate = appState.appInfo.creationDate {
@@ -341,7 +341,7 @@ struct FilesView: View {
 //                            .padding(.top)
 
 
-                        Button("\(sizeType == "Logical" ? totalSelectedSize.logical : totalSelectedSize.real)") {
+                        Button {
                             showCustomAlert(enabled: confirmAlert, title: String(localized: "Warning"), message: String(localized: "Are you sure you want to remove these files?"), style: .warning, onOk: {
                                 Task {
 
@@ -419,8 +419,8 @@ struct FilesView: View {
 
                                 }
                             })
-
-
+                        } label: {
+                            Text(verbatim: "\(sizeType == "Logical" ? totalSelectedSize.logical : totalSelectedSize.real)")
                         }
                         .buttonStyle(UninstallButton(isEnabled: !appState.selectedItems.isEmpty))
                         .disabled(appState.selectedItems.isEmpty)
@@ -555,7 +555,7 @@ struct FileDetailsItem: View {
 
             let displaySize = sizeType == "Real" ? formatByte(size: size!).human :
             formatByte(size: sizeL!).human
-            Text("\(displaySize)")
+            Text(verbatim: "\(displaySize)")
 
         }
         .contextMenu {

--- a/Pearcleaner/Views/RegularMode.swift
+++ b/Pearcleaner/Views/RegularMode.swift
@@ -104,13 +104,13 @@ struct RegularMode: View {
             VStack(spacing: 0) {
                 HStack {
                     Spacer()
-                    Picker("", selection: $appState.currentPage) {
+                    Picker(selection: $appState.currentPage) {
                         ForEach(CurrentPage.allCases) { page in
                             Text(page.title)
                                 .font(.title3)
                                 .tag(page)
                         }
-                    }
+                    } label: { EmptyView() }
                     .buttonStyle(.borderless)
                     .padding(2)
                     .padding(.vertical, 2)

--- a/Pearcleaner/Views/ZombieView.swift
+++ b/Pearcleaner/Views/ZombieView.swift
@@ -127,7 +127,7 @@ struct ZombieView: View {
 
                     // Item selection and sorting toolbar
                     HStack {
-                        Toggle("", isOn: Binding(
+                        Toggle(isOn: Binding(
                             get: {
                                 if searchZ.isEmpty {
                                     // All items are selected if no filter is applied and all items are selected
@@ -158,7 +158,7 @@ struct ZombieView: View {
 
                                 updateTotalSizes()
                             }
-                        ))
+                        )) { EmptyView() }
                         .toggleStyle(SimpleCheckboxToggleStyle())
                         .help("All checkboxes")
 
@@ -170,10 +170,10 @@ struct ZombieView: View {
 
 
 
-                        Button("") {
+                        Button {
                             selectedSortAlpha.toggle()
                             updateMemoizedFiles(for: searchZ, sizeType: sizeType, selectedSortAlpha: selectedSortAlpha, force: true)
-                        }
+                        } label: { EmptyView() }
                         .buttonStyle(SimpleButtonStyle(icon: "line.3.horizontal.decrease.circle", label: String(localized: selectedSortAlpha ? "Name" : "Size"), help: String(localized: selectedSortAlpha ? "Sorted alphabetically" : "Sorted by size"), size: 16))
 
 
@@ -427,7 +427,7 @@ struct ZombieFileDetailsItem: View {
     var body: some View {
 
         HStack(alignment: .center, spacing: 20) {
-            Toggle("", isOn: $isSelected)
+            Toggle(isOn: $isSelected) { EmptyView() }
             .toggleStyle(SimpleCheckboxToggleStyle())
 
             if let appIcon = icon {

--- a/Pearcleaner/Views/ZombieView.swift
+++ b/Pearcleaner/Views/ZombieView.swift
@@ -105,14 +105,14 @@ struct ZombieView: View {
                                     VStack(alignment: .leading, spacing: 5) {
                                         Text("Total size of files:")
                                             .font(.callout).fontWeight(.bold)
-                                        Text("")
+                                        Text(verbatim: "")
                                             .font(.footnote)
                                     }
                                     Spacer()
                                     VStack(alignment: .trailing, spacing: 5) {
-                                        Text("\(displaySizeTotal)").font(.callout).fontWeight(.bold)//.help("Total size on disk")
+                                        Text(verbatim: "\(displaySizeTotal)").font(.callout).fontWeight(.bold)//.help("Total size on disk")
 
-                                        Text("\(selectedZombieItemsLocal.count) \(String(localized: "of")) \(searchZ.isEmpty ? appState.zombieFile.fileSize.count : memoizedFiles.count) \(appState.zombieFile.fileSize.count == 1 ? "\(String(localized: "item"))" : "\(String(localized: "items"))")")
+                                        Text(verbatim: "\(selectedZombieItemsLocal.count) \(String(localized: "of")) \(searchZ.isEmpty ? appState.zombieFile.fileSize.count : memoizedFiles.count) \(appState.zombieFile.fileSize.count == 1 ? "\(String(localized: "item"))" : "\(String(localized: "items"))")")
                                             .font(.footnote).foregroundStyle(.secondary)
                                     }
 
@@ -218,7 +218,7 @@ struct ZombieView: View {
                         }
                         .buttonStyle(RescanButton())
 
-                        Button("\(sizeType == "Logical" ? totalLogicalSizeUninstallBtn : totalRealSizeUninstallBtn)") {
+                        Button {
                             showCustomAlert(enabled: confirmAlert, title: String(localized: "Warning"), message: String(localized: "Are you sure you want to remove these files?"), style: .warning, onOk: {
                                 Task {
 
@@ -264,7 +264,7 @@ struct ZombieView: View {
 
                             })
 
-                            }
+                        } label: { Text(verbatim: "\(sizeType == "Logical" ? totalLogicalSizeUninstallBtn : totalRealSizeUninstallBtn)") }
                             .buttonStyle(UninstallButton(isEnabled: !selectedZombieItemsLocal.isEmpty))
                             .disabled(selectedZombieItemsLocal.isEmpty)
 
@@ -486,7 +486,7 @@ struct ZombieFileDetailsItem: View {
             let displaySize = sizeType == "Real" ? formatByte(size: size!).human :
             formatByte(size: sizeL!).human
 
-            Text("\(displaySize)")
+            Text(verbatim: "\(displaySize)")
 
         }
         .contextMenu {


### PR DESCRIPTION
I found many unwanted stings you can exclude from the translation files instead of marking them as "Don't Translate."

This PR contains two ways to exclude stings: 
1. Text(verbatim: ) 
3. "" to EmptyView()

I kept "GitHub" in case that's on purpose.

This should make translating this app easier. The app should behave the same. But because I'm not familiar with all the views, I'm not 100% sure. Please give it some test.