### PR TITLE
Added size label for development environment folders.

### DIFF
--- a/Pearcleaner/Views/DevelopmentView.swift
+++ b/Pearcleaner/Views/DevelopmentView.swift
@@ -109,6 +109,7 @@ struct PathRowView: View {
     @State private var exists: Bool = false
     @State private var isEmpty: Bool = false
     @State private var matchingPaths: [String] = []
+    @AppStorage("settings.general.sizeType") var sizeType: String = "Real"
 
     var body: some View {
 
@@ -116,11 +117,23 @@ struct PathRowView: View {
             if !matchingPaths.isEmpty {
                 ForEach(matchingPaths, id: \.self) { matchedPath in
                     VStack(alignment: .leading, spacing: 10) {
-                        Text(matchedPath)
-                            .font(.headline)
-                            .foregroundColor(.primary)
-                            .lineLimit(1)
-                            .truncationMode(.tail)
+                        HStack {
+                            
+                            Text(matchedPath)
+                                .font(.headline)
+                                .foregroundColor(.primary)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                            
+                            Spacer()
+                            
+                            if let url = URL(string: matchedPath) {
+                                let size = sizeType == "Real" ? totalSizeOnDisk(for: url).real : totalSizeOnDisk(for: url).logical
+                                let formattedSize = formatByte(size: size).human
+                                Text(formattedSize)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
 
                         HStack {
 


### PR DESCRIPTION
This pull request includes an enhancement to the `PathRowView` in the `DevelopmentView.swift` file. The changes introduce a new feature to display the size of each matched path in the user interface.

Enhancements to `PathRowView`:

* [`Pearcleaner/Views/DevelopmentView.swift`](diffhunk://#diff-d799fe6920cc38fb524396f2eef03bd06d7c5235a4563bdbd2f198240d3aab65R112-R137): Added a new `@AppStorage` property `sizeType` to get the user's preference for size type ("Real" or "Logical").
* [`Pearcleaner/Views/DevelopmentView.swift`](diffhunk://#diff-d799fe6920cc38fb524396f2eef03bd06d7c5235a4563bdbd2f198240d3aab65R112-R137): Modified the `ForEach` loop to include a `HStack` that displays the formatted size of each matched path based on the selected `sizeType`.