### PR TITLE
feature: add documentation cache folder for Xcode

### DIFF
--- a/Pearcleaner/Views/DevelopmentView.swift
+++ b/Pearcleaner/Views/DevelopmentView.swift
@@ -419,6 +419,7 @@ struct PathLibrary {
                 "~/Library/Developer/DeveloperDiskImages/",
                 "~/Library/Developer/Xcode/Archives/",
                 "~/Library/Developer/Xcode/DerivedData/",
+                "~/Library/Developer/Xcode/DocumentationCache/",
                 "~/Library/Developer/Xcode/iOS DeviceSupport/",
                 "~/Library/Developer/Xcode/tvOS DeviceSupport/",
                 "~/Library/Developer/Xcode/watchOS DeviceSupport/",


### PR DESCRIPTION
It seems that documentation cache folder is not considered in the Developer Environment-> Xcode.
So this PR adds support for this folder.
<img width="618" alt="Screenshot 2025-04-05 at 16 47 58" src="https://github.com/user-attachments/assets/85b072b9-c66b-4a1f-826e-fefb767bbbca" />
Of course, any comments are welcome!