### PR TITLE
fix(vi-locale): remove redundant new line

### DIFF
--- a/Pearcleaner/Resources/Localizable.xcstrings
+++ b/Pearcleaner/Resources/Localizable.xcstrings
@@ -12908,7 +12908,7 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dịch vụ đã được đăng ký và bật.\n"
+            "value" : "Dịch vụ đã được đăng ký và bật."
           }
         },
         "zh-HK" : {


### PR DESCRIPTION
In previous PR (#246) I was in the process of rebasing and squashing commits to tidy things up when you merged the PR, so the previous PR missed this commit, my sincere apologies for this oversight.

Also, if there are any contextual or language inconsistencies during usage, I will open additional PRs to make corrections.

Btw, it seems that the content in this popup hasn’t been included in the language pack yet.

<img width="283" alt="SCR-20250501-bpjf" src="https://github.com/user-attachments/assets/7301d148-75c4-486b-ac78-38ad8a63ffe5" />


Thank you!



