### PR TITLE
Add Deno and pnpm as development tools

### DIFF
--- a/Pearcleaner/Views/DevelopmentView.swift
+++ b/Pearcleaner/Views/DevelopmentView.swift
@@ -730,6 +730,9 @@ struct PathLibrary {
                 "~/.cursor/",
                 "~/.cursor/extensions/"
             ]),
+            PathEnv(name: "Deno", paths: [
+                "~/Library/Caches/deno"
+            ]),
             PathEnv(name: "Go Modules", paths: [
                 "~/go/bin/",
                 "~/go/pkg/mod/"
@@ -759,7 +762,8 @@ struct PathLibrary {
                 "/usr/local/lib/node_modules/",
                 "~/.nvm/versions/node/*/",
                 "~/.npm/",
-                "~/.nvm/"
+                "~/.nvm/",
+                "~/Library/pnpm/store"
             ]),
             PathEnv(name: "Pip", paths: [
                 "~/.cache/pip/"


### PR DESCRIPTION
This adds [deno](https://deno.com/) and [pnpm](https://pnpm.io/) paths as development tools.

Sources:
- [pnpm location](https://stackoverflow.com/questions/55403775/how-to-get-pnpm-store-directory)
- [deno location](https://stackoverflow.com/questions/61799309/where-can-i-see-deno-downloaded-packages)