### PR TITLE
Finder extension icon

### DIFF
--- a/FinderOpen/FinderOpen.swift
+++ b/FinderOpen/FinderOpen.swift
@@ -27,8 +27,14 @@ class FinderOpen: FIFinderSync {
                selectedItemURLs.count == 1, selectedItemURLs.first?.pathExtension == "app" {
                 // Add menu item if the selected item is a .app file
                 let menuItem = NSMenuItem(title: String(localized: "Pearcleaner Uninstall"), action: #selector(openInMyApp), keyEquivalent: "")
+                
+                if let sharedDefaults = UserDefaults(suiteName: "group.com.alienator88.Pearcleaner") {
+                    let iconEnabled = sharedDefaults.bool(forKey: "settings.general.finderExtensionIcon")
+                    print(iconEnabled)
+                    menuItem.image = iconEnabled ? NSImage(named: "Icon") : nil
+                }
+                menuItem.image = NSImage(named: "Icon")
                 menu.addItem(menuItem)
-
             }
         }
 

--- a/Pearcleaner/Resources/Localizable.xcstrings
+++ b/Pearcleaner/Resources/Localizable.xcstrings
@@ -9543,6 +9543,50 @@
         }
       }
     },
+    "Enable Finder extension" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用Finder扩展"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用Finder擴展图标"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用Finder擴展"
+          }
+        }
+      }
+    },
+    "Enable icon for Finder extension" : {
+      "localizations" : {
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "启用Finder扩展图标"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用Finder擴展图标"
+          }
+        },
+        "zh-HK" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "啟用Finder擴展图标"
+          }
+        }
+      }
+    },
     "Enabled" : {
       "localizations" : {
         "de" : {
@@ -11217,7 +11261,7 @@
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Finder 延伸功能"
+            "value" : "Finder延伸功能"
           }
         }
       }

--- a/Pearcleaner/Views/Settings/General.swift
+++ b/Pearcleaner/Views/Settings/General.swift
@@ -25,6 +25,7 @@ struct GeneralSettingsTab: View {
     @AppStorage("settings.general.spotlight") private var spotlight = false
     @AppStorage("settings.general.permanentDelete") private var permanentDelete: Bool = false
     @AppStorage("settings.general.searchSensitivity") private var sensitivityLevel: SearchSensitivityLevel = .strict
+    @AppStorage("settings.general.finderExtensionIcon", store: UserDefaults(suiteName: "group.com.alienator88.Pearcleaner")) private var finderExtensionIcon: Bool = true
 
     var body: some View {
         VStack(spacing: 20) {
@@ -251,7 +252,7 @@ struct GeneralSettingsTab: View {
                             VStack {
 
                                 HStack(spacing: 0) {
-                                    Text("Enable context menu extension for Finder")
+                                    Text("Enable Finder extension")
                                         .font(.callout)
                                         .foregroundStyle(ThemeColors.shared(for: colorScheme).primaryText)
 
@@ -272,15 +273,10 @@ struct GeneralSettingsTab: View {
                                     .padding(.leading, 5)
                                     Spacer()
                                 }
-
-
                             }
 
-
-
-
                             Spacer()
-
+                            
                             Toggle(isOn: $appState.finderExtensionEnabled, label: {
                             })
                             .toggleStyle(SettingsToggle())
@@ -291,13 +287,29 @@ struct GeneralSettingsTab: View {
                                     manageFinderPlugin(install: false)
                                 }
                             }
-
-
                         }
-
+                        
+                        if appState.finderExtensionEnabled {
+                            HStack(spacing: 0) {
+                                Image(systemName: "")
+                                    .resizable()
+                                    .scaledToFit()
+                                    .frame(width: 15, height: 15)
+                                    .padding(.trailing)
+                                    .foregroundStyle(ThemeColors.shared(for: colorScheme).primaryText)
+                                Text("Enable icon for Finder extension")
+                                    .font(.callout)
+                                    .foregroundStyle(ThemeColors.shared(for: colorScheme).primaryText)
+                                
+                                Spacer()
+                                
+                                Toggle(isOn: $finderExtensionIcon, label: {
+                                })
+                                .toggleStyle(SettingsToggle())
+                            }
+                        }
                     }
                     .padding(5)
-
                 })
 
             // === CLI ==========================================================================================================


### PR DESCRIPTION
1. add option to enable Finder extension icon
2. Chang string from `context menu extension for Finder` to `Finder extension`
<img height="300" alt="image" src="https://github.com/user-attachments/assets/971bf689-30e7-4892-806a-fce353741364" />

**Note: I have no access to App Group, so the code has not been tested, but I assume they will work😂, can you test that?**
<img height="300" alt="image" src="https://github.com/user-attachments/assets/77741e7b-750d-4746-a983-6a0523b00a06" />
