### PR TITLE
Update localized strings for "Homebrew" in Chinese

### DIFF
--- a/Pearcleaner/Resources/Localizable.xcstrings
+++ b/Pearcleaner/Resources/Localizable.xcstrings
@@ -21347,19 +21347,19 @@
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自製醫生"
+            "value" : "Homebrew 診斷"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自制医生"
+            "value" : "Homebrew 诊断"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自製醫生"
+            "value" : "Homebrew 診斷"
           }
         }
       }
@@ -21647,19 +21647,19 @@
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自製版本"
+            "value" : "Homebrew 版本"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自制版本"
+            "value" : "Homebrew 版本"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "自製版本"
+            "value" : "Homebrew 版本"
           }
         }
       }
@@ -41701,19 +41701,19 @@
         "zh-HK" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在運行自製軟件清理"
+            "value" : "正在運行Homebrew清理"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在运行自制软件清理"
+            "value" : "正在运行Homebrew清理"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在運行自製軟件清理"
+            "value" : "正在運行Homebrew清理"
           }
         }
       }


### PR DESCRIPTION
Greetings to the authors/contributors! I've been loving to use PearCleaner to uninstall apps on my Mac, and it works so good for me. I'd like to thank you for your great work! 🥰

As a Chinese user, I have found one translation issue: 

Since **Homebrew** is a software, it would be more clear not to translate it. Otherwise, Chinese users may misunderstand it as "**homemade**" or "**DIY**", rather than the name of the package management software. 

So I tried to make a commit to correct this. I would appreciate it if you merge this PR or fix this issue more perfectly. Hope you are doing well!😘