### PR TITLE
add Python dev env

### DIFF
--- a/Pearcleaner/Views/DevelopmentView.swift
+++ b/Pearcleaner/Views/DevelopmentView.swift
@@ -170,7 +170,7 @@ struct EnvironmentCleanerView: View {
 
                 // Add workspace storage cleaner for certain IDEs
                 let workspaceIDEs = ["VS Code", "Cursor", "Zed"]
-                let packageManagers = ["Pip"]
+                let packageManagers = ["Python"]
 
                 if workspaceIDEs.contains(selectedEnvironment.name) {
                     WorkspaceStorageCleanerView(ideName: selectedEnvironment.name)
@@ -1670,6 +1670,18 @@ struct PathLibrary {
             PathEnv(name: "Pyenv", paths: [
                 "~/.pyenv/",
                 "~/.pyenv/cache/"
+            ]),
+            PathEnv(name: "Python", paths: [
+                "/usr/bin/python3", // interpreter: system
+                "/usr/local/bin/python*", // interpreters: python.org
+                "/opt/homebrew/bin/python*", // interpreters: homebrew
+                "~/.local/bin/python*", // interpreters: uv
+                "~/.local/share/virtualenvs/**/bin/python", // environments: pipenv
+                "~/Library/Caches/pypoetry/virtualenvs/**/bin/python", // environments: poetry
+                "~/.pyenv/versions/**/bin/python", // environments: pyenv
+                "~/.virtualenvs/**/bin/python", // environments: virtualenvwrapper
+                "~/anaconda3/envs/**/bin/python", // environments: anaconda
+                "~/miniconda3/envs/**/bin/python", // environments: miniconda
             ]),
             PathEnv(name: "Ruby Gems", paths: [
                 "~/.gem/",


### PR DESCRIPTION
Tying the new python environment feature to Pip dev env doesn't make sense. Nor adding other dev envs like Uv to it (at least to me).

So I've added a Python dev env with all the possible [default] paths a python interpreter can be located at on macOS (that I can think of). So if any of the paths (i.e. python interpreters) exist, we get the feature enabled.

If I knew Swift, I would made the following changes (alas!):
- Use the [available] paths in a dropdown list here: <img width="196" height="31" alt="image" src="https://github.com/user-attachments/assets/b9c342d7-7ba1-46ea-9d10-b29876e2cfe1" />
- hide the 'Delete Folder' and 'Delete Contents' button across the Python dev env

One potential related feature could be that when we go to, say, pyenv dev env, we use the pyenv paths to list the python packages and similarly for others like uv, etc. While the Python dev env will continue to have _all_ the paths plus a custom path picker.