### PR TITLE
Fix selecting VS Code for removal automatically selecting items related to VS Code insiders (and vice-versa)

### DIFF
--- a/Pearcleaner/Logic/Conditions.swift
+++ b/Pearcleaner/Logic/Conditions.swift
@@ -128,10 +128,16 @@ var conditions: [Condition] = [
         includeForce: nil
     ),
     Condition(
-        bundle_id: "com.microsoft.vscode",
+        bundle_id: "com.microsoft.VSCode",
         include: ["vscode"],
-        exclude: [],
+        exclude: ["vscodeinsiders", "insiders"],
         includeForce: ["\(home)/Library/Application Support/Code/"]
+    ),
+    Condition(
+        bundle_id: "com.microsoft.VSCodeInsiders",
+        include: ["vscodeinsiders", "insiders"],
+        exclude: [],
+        includeForce: ["\(home)/Library/Application Support/Code - Insiders/"]
     ),
     Condition(
         bundle_id: "com.facebook.archon.developerid",


### PR DESCRIPTION
Not sure if this code is fully correct. Please refactor it as you wish.

I just deleted all of my VS Code Insiders related stuff because I didn't pay close attention when I selected to remove VS Code. Hope this can be improved.