### PR TITLE
Update Homebrew installation command for pearcleaner

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Pre-compiled, always up-to-date versions are available from my [releases](https:
 
 You can add the app via Homebrew:
 ```
-brew install pearcleaner
+brew install --cask pearcleaner
 ```
 </details>
 


### PR DESCRIPTION
Pearcleaner is a cask and this makes it the same as on the homebrew site: https://formulae.brew.sh/cask/pearcleaner