### PR TITLE
Fix race in CLI list-orphaned / remove-orphaned that produced false positives

### DIFF
--- a/Pearcleaner/Logic/CLI.swift
+++ b/Pearcleaner/Logic/CLI.swift
@@ -87,17 +87,19 @@ struct PearCLI: ParsableCommand {
         )
 
         func run() throws {
-            // Get installed apps for filtering
-            DispatchQueue.global(qos: .userInitiated).async {
-                let _ = getSortedApps(paths: PearCLI.fsm.folderPaths, useStreaming: false)
-            }
-
+            // Load the installed-apps list synchronously, then pass it directly to the
+            // searcher. The previous code dispatched getSortedApps onto a background
+            // queue and read AppState.shared.sortedApps on the very next line, which
+            // raced — sortedApps was almost always still empty when the orphan matcher
+            // ran, so every residual file appeared as an orphan (massive false
+            // positives compared to the GUI's Orphaned Files view).
+            let sortedApps = getSortedApps(paths: PearCLI.fsm.folderPaths, useStreaming: false)
 
             // Find orphaned files
             let foundPaths = ReversePathsSearcher(
                 locations: PearCLI.locations,
                 fsm: PearCLI.fsm,
-                sortedApps: AppState.shared.sortedApps
+                sortedApps: sortedApps
             )
                 .reversePathsSearchCLI()
 
@@ -209,16 +211,14 @@ struct PearCLI: ParsableCommand {
 
         func run() throws {
 
-            // Get installed apps for filtering
-            DispatchQueue.global(qos: .userInitiated).async {
-                let _ = getSortedApps(paths: PearCLI.fsm.folderPaths, useStreaming: false)
-            }
+            // Load installed apps synchronously; see ListOrphaned for the rationale.
+            let sortedApps = getSortedApps(paths: PearCLI.fsm.folderPaths, useStreaming: false)
 
             // Find orphaned files
             let foundPaths = ReversePathsSearcher(
                 locations: PearCLI.locations,
                 fsm: PearCLI.fsm,
-                sortedApps: AppState.shared.sortedApps
+                sortedApps: sortedApps
             )
                 .reversePathsSearchCLI()
 


### PR DESCRIPTION
## Problem

`pear list-orphaned` and `pear remove-orphaned` produce massive false positives — they flag files belonging to currently-installed apps as orphans.

On my machine `pear list-orphaned` returns **88 items** while the GUI's "Orphaned Files" view (running on the same Pearcleaner build, same machine, same instant) returns **9 items**. The 79 extra items include files for ChatGPT, Discord, kitty, Obsidian, QQ, VS Code, WeChat, ZeroTier, zoom, Clash Verge, Ryujinx, and 哔哩哔哩 (bilibili) — all currently installed and in active use.

If a user runs `pear remove-orphaned` (or follows the displayed list and deletes manually), they will trash data for apps that are still installed.

## Root cause

`Logic/CLI.swift` `ListOrphaned.run()` and `RemoveOrphaned.run()` both have:

```swift
DispatchQueue.global(qos: .userInitiated).async {
    let _ = getSortedApps(paths: PearCLI.fsm.folderPaths, useStreaming: false)
}

// Find orphaned files
let foundPaths = ReversePathsSearcher(
    locations: PearCLI.locations,
    fsm: PearCLI.fsm,
    sortedApps: AppState.shared.sortedApps   // ← almost always empty here
)
    .reversePathsSearchCLI()
```

`getSortedApps` is dispatched onto a background queue and its return value is discarded with `let _ =`. The very next line synchronously reads `AppState.shared.sortedApps`. The background task hasn't begun (let alone finished and updated `AppState`) by the time the read happens, so the matcher operates on an empty installed-apps list. With nothing to match against, every residual file under `~/Library/Application Support/`, `~/Library/Caches/`, etc. is reported as an orphan.

The GUI does not have this bug because `loadApps()` populates `AppState.shared.sortedApps` early during launch, well before the user navigates to the Orphaned Files view.

## Fix

Call `getSortedApps` synchronously and pass the returned `[AppInfo]` directly to `ReversePathsSearcher`. This mirrors what `loadAppsAsync` in `Logic.swift` already does (`await Task.detached { getSortedApps(...) }.value`), just without the `await` since CLI's `run()` is synchronous.

```swift
let sortedApps = getSortedApps(paths: PearCLI.fsm.folderPaths, useStreaming: false)

let foundPaths = ReversePathsSearcher(
    locations: PearCLI.locations,
    fsm: PearCLI.fsm,
    sortedApps: sortedApps
)
    .reversePathsSearchCLI()
```

Same change applied in both `ListOrphaned` and `RemoveOrphaned`.

## Test plan

- [x] `pear list-orphaned` now returns the same set of items as the GUI's Orphaned Files view (9 on my machine, matching exactly).
- [ ] `pear remove-orphaned` no longer trashes files for installed apps.
- [ ] GUI's Orphaned Files view still works (untouched code path).