### PR TITLE
Fix glass effect rendering as solid gray on macOS 27 Beta (Issue #577)

### DIFF
--- a/Pearcleaner/Style/Styles.swift
+++ b/Pearcleaner/Style/Styles.swift
@@ -648,8 +648,14 @@ struct ifGlassAvailableMain: ViewModifier {
 
     func body(content: Content) -> some View {
         if #available(macOS 26.0, *) {
-            content
-                .glassEffect(glassEffect == "Regular" ? .regular : .clear, in: .rect(cornerRadius: 20))
+            if glassEffect == "Regular" {
+                content
+                    .glassEffect(.regular, in: .rect(cornerRadius: 20))
+            } else {
+                content
+                    .background(GlassEffect(material: .sidebar, blendingMode: .behindWindow))
+                    .clipShape(RoundedRectangle(cornerRadius: 20))
+            }
         }
         else {
             content
@@ -676,14 +682,23 @@ struct ifGlassAvailableSidebar: ViewModifier {
 
     func body(content: Content) -> some View {
         if #available(macOS 26.0, *) {
-            content
-                .background(.ultraThinMaterial.opacity(glassEffect == "Regular" ? 0 : 0.7))
-                .glassEffect(glassEffect == "Regular" ? .regular : .clear, in: .rect(cornerRadius: 20))
-                .clipShape(RoundedRectangle(cornerRadius: 20))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 20)
-                        .strokeBorder(ThemeColors.shared(for: colorScheme).primaryText.opacity(0.2), lineWidth: colorScheme == .light ? 1 : 0)
-                }
+            if glassEffect == "Regular" {
+                content
+                    .glassEffect(.regular, in: .rect(cornerRadius: 20))
+                    .clipShape(RoundedRectangle(cornerRadius: 20))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 20)
+                            .strokeBorder(ThemeColors.shared(for: colorScheme).primaryText.opacity(0.2), lineWidth: colorScheme == .light ? 1 : 0)
+                    }
+            } else {
+                content
+                    .background(GlassEffect(material: .sidebar, blendingMode: .behindWindow))
+                    .clipShape(RoundedRectangle(cornerRadius: 20))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 20)
+                            .strokeBorder(ThemeColors.shared(for: colorScheme).primaryText.opacity(0.2), lineWidth: colorScheme == .light ? 1 : 0)
+                    }
+            }
         }
         else {
             content


### PR DESCRIPTION
### Summary
Resolves #577 

This PR addresses a critical rendering regression introduced in macOS 27 Beta, where the `Clear` glass effect setting fails to composite correctly, resulting in the sidebar rendering as an opaque `#2d2e33` color block instead of the expected translucent blur.

### Root Cause Analysis & Technical Approach
The root architectural frames (`SettingsWindow` and `MainWindow`) are explicitly painted with a solid `primaryBG` color (`#1a1b1f`). In the latest beta compositor, the custom `.glassEffect(.clear)` modifier provided by `AlinFoundation` is unable to pierce through this underlying solid SwiftUI background layer. Consequently, it only blurs the immediate solid background rather than the user's desktop.

To resolve this at the compositing level, I have refactored both `ifGlassAvailableMain` and `ifGlassAvailableSidebar` to utilize Apple's native `NSVisualEffectView` when the `Clear` effect is active. By explicitly setting the blending mode to `.behindWindow`, we instruct the macOS WindowServer to punch a hole through all underlying SwiftUI backgrounds and blur the physical desktop wallpaper directly behind the application frame. This safely and completely restores the native translucent appearance without causing side effects on the `Regular` mode.

### Developer Checklist
- [x] Investigated and identified the compositing failure on macOS 27 Beta.
- [x] Swapped the failing `.glassEffect` modifier with a robust, native `NSVisualEffectView` implementation for the `Clear` state.
- [x] Applied `.behindWindow` blending to explicitly override the solid root window backgrounds.
- [x] Verified that the `Regular` glass effect mode remains fully intact and unaffected.
- [x] Validated flawless local compilation and UI rendering.

*Proof of Rendering:*
<img width="1273" height="773" alt="Screenshot 2026-06-11 at 5 48 29 PM" src="https://github.com/user-attachments/assets/d0fba8e6-1276-4891-ab23-b2406352b3d3" />
<img width="1266" height="796" alt="Screenshot 2026-06-11 at 5 48 35 PM" src="https://github.com/user-attachments/assets/2888f5af-ccb9-404d-be16-eb6f8146bf9b" />
