### PR TITLE
Improve Sentinel event handling and observability

### DIFF
--- a/PearcleanerSentinel/main.swift
+++ b/PearcleanerSentinel/main.swift
@@ -7,39 +7,59 @@
 
 
 import AppKit
+import OSLog
+
+private let logger = Logger(
+    subsystem: "com.alienator88.Pearcleaner",
+    category: "Sentinel"
+)
 
 main()
 
 var globalFileWatcher: FileWatcher?
 
 func startGlobalFileWatcher() {
+    guard globalFileWatcher == nil else {
+        logger.debug("Trash watcher is already running")
+        return
+    }
+
     let home = FileManager.default.homeDirectoryForCurrentUser.path
     globalFileWatcher = FileWatcher(["\(home)/.Trash"])
     globalFileWatcher?.queue = DispatchQueue.global()
     globalFileWatcher?.callback = { event in
+        guard event.created || event.renamed else { return }
         checkApp(file: event.path)
     }
     globalFileWatcher?.start()
+    logger.info("Started Trash watcher; Sentinel only observes trashed app bundles")
 }
 
 func stopGlobalFileWatcher() {
+    guard globalFileWatcher != nil else {
+        logger.debug("Trash watcher is already stopped")
+        return
+    }
+
     globalFileWatcher?.stop()
     globalFileWatcher = nil
+    logger.info("Stopped Trash watcher")
 }
 
 func setupNotificationListener() {
     let notificationCenter = DistributedNotificationCenter.default()
-    notificationCenter.addObserver(forName: Notification.Name("Pearcleaner.StartFileWatcher"), object: nil, queue: nil) { notification in
-        print("Received start notification")
+    notificationCenter.addObserver(forName: Notification.Name("Pearcleaner.StartFileWatcher"), object: nil, queue: nil) { _ in
+        logger.debug("Received start notification")
         startGlobalFileWatcher()
     }
-    notificationCenter.addObserver(forName: Notification.Name("Pearcleaner.StopFileWatcher"), object: nil, queue: nil) { notification in
-        print("Received stop notification")
+    notificationCenter.addObserver(forName: Notification.Name("Pearcleaner.StopFileWatcher"), object: nil, queue: nil) { _ in
+        logger.debug("Received stop notification")
         stopGlobalFileWatcher()
     }
 }
 
 func main() {
+    logger.info("Sentinel launched")
     setupNotificationListener()
     startGlobalFileWatcher()
     RunLoop.main.run()
@@ -48,19 +68,35 @@ func main() {
 
 func checkApp(file: String) {
     let app = URL(fileURLWithPath: file)
-    let appExt = app.pathExtension
-    if appExt == "app" {
-        if let appBundle = Bundle(url: app) {
-            if appBundle.bundleIdentifier == "com.alienator88.Pearcleaner" {
-                return
-            } else {
-                if FileManager.default.isInTrash(app) {
-                    NSWorkspace.shared.open(URL(string: "pear://openApp?path=\(file)")!)
-                }
-            }
-        } else {
-            print("Error: Unable to get bundle information for \(file)")
-        }
+    guard app.pathExtension.caseInsensitiveCompare("app") == .orderedSame,
+          FileManager.default.isInTrash(app) else {
+        return
+    }
+
+    guard let appBundle = Bundle(url: app) else {
+        logger.error("Unable to read bundle information for path: \(file, privacy: .private(mask: .hash))")
+        return
+    }
+
+    guard appBundle.bundleIdentifier != "com.alienator88.Pearcleaner" else {
+        logger.debug("Ignoring Pearcleaner's own app bundle")
+        return
+    }
+
+    var components = URLComponents()
+    components.scheme = "pear"
+    components.host = "openApp"
+    components.queryItems = [URLQueryItem(name: "path", value: file)]
+
+    guard let deepLink = components.url else {
+        logger.error("Unable to create deep link for path: \(file, privacy: .private(mask: .hash))")
+        return
+    }
+
+    if NSWorkspace.shared.open(deepLink) {
+        logger.notice("Opened Pearcleaner for a trashed app bundle: \(file, privacy: .private(mask: .hash))")
+    } else {
+        logger.error("Failed to open Pearcleaner for path: \(file, privacy: .private(mask: .hash))")
     }
 }
 


### PR DESCRIPTION
## Summary

- restrict Sentinel handling to created or renamed app bundles in the Trash
- add privacy-preserving unified logging for lifecycle, watcher, deep-link, and error events
- prevent duplicate watcher startup
- safely encode file paths in `pear://` deep links

## Context

Sentinel only watches `~/.Trash` and contains no file-deletion code, so it cannot directly remove `~/.local/bin/claude`. These changes make Sentinel activity auditable and avoid processing unrelated FSEvents while investigating reports like #581.

Logs can be inspected with:

```sh
log stream --info --predicate 'subsystem == "com.alienator88.Pearcleaner" && category == "Sentinel"'
```

## Validation

- `PearcleanerSentinel` Debug target builds successfully with code signing disabled
- verified runtime unified logs for Sentinel launch and Trash watcher startup
- `git diff --check` passes
- full upstream app build remains blocked by pre-existing hard-coded `/Users/alin/GitHub/...` module-map paths; this is unrelated to the Sentinel change

Closes #581